### PR TITLE
Update ODOO_BASE_DIR attributes and set ODOO_DAEMON_USER as the owner.

### DIFF
--- a/13/debian-10/rootfs/opt/bitnami/scripts/odoo/postunpack.sh
+++ b/13/debian-10/rootfs/opt/bitnami/scripts/odoo/postunpack.sh
@@ -28,6 +28,8 @@ for dir in "$ODOO_ADDONS_DIR" "$ODOO_CONF_DIR" "$ODOO_DATA_DIR" "$ODOO_LOGS_DIR"
     # Use daemon:root ownership for compatibility when running as a non-root user
     configure_permissions_ownership "$dir" -d "775" -f "664" -u "$ODOO_DAEMON_USER" -g "root"
 done
+# Use daemon user ownership for compatibility when running as a non-root user
+chown "$ODOO_DAEMON_USER" "$ODOO_BASE_DIR"
 
 # Create folders that existed in previous versions of this image with proper permissions/ownership
 # TODO: Remove this block in a future release

--- a/14/debian-10/rootfs/opt/bitnami/scripts/odoo/postunpack.sh
+++ b/14/debian-10/rootfs/opt/bitnami/scripts/odoo/postunpack.sh
@@ -28,6 +28,8 @@ for dir in "$ODOO_ADDONS_DIR" "$ODOO_CONF_DIR" "$ODOO_DATA_DIR" "$ODOO_LOGS_DIR"
     # Use daemon:root ownership for compatibility when running as a non-root user
     configure_permissions_ownership "$dir" -d "775" -f "664" -u "$ODOO_DAEMON_USER" -g "root"
 done
+# Use daemon user ownership for compatibility when running as a non-root user
+chown "$ODOO_DAEMON_USER" "$ODOO_BASE_DIR"
 
 # Create folders that existed in previous versions of this image with proper permissions/ownership
 # TODO: Remove this block in a future release

--- a/15/debian-10/rootfs/opt/bitnami/scripts/odoo/postunpack.sh
+++ b/15/debian-10/rootfs/opt/bitnami/scripts/odoo/postunpack.sh
@@ -28,6 +28,8 @@ for dir in "$ODOO_ADDONS_DIR" "$ODOO_CONF_DIR" "$ODOO_DATA_DIR" "$ODOO_LOGS_DIR"
     # Use daemon:root ownership for compatibility when running as a non-root user
     configure_permissions_ownership "$dir" -d "775" -f "664" -u "$ODOO_DAEMON_USER" -g "root"
 done
+# Use daemon user ownership for compatibility when running as a non-root user
+chown "$ODOO_DAEMON_USER" "$ODOO_BASE_DIR"
 
 # Create folders that existed in previous versions of this image with proper permissions/ownership
 # TODO: Remove this block in a future release


### PR DESCRIPTION
Signed-off-by: Sylvain Bonnemaison <sylvain.bonnemaison@ti-mm.com>

**Description of the change**

Update `postunpack.sh` shell script with following features :
- update `ODOO_BASE_DIR` directory attributes
- set `ODOO_DAEMON_USER` as the owner of `ODOO_BASE_DIR` directory . 

**Benefits**

`postunpack.sh` script is able to update `ODOO_BASE_DIR` base directory content when running container using  `ODOO_DAEMON_USER` user, instead of `roor` user.

**Applicable issues**

Issue #118 